### PR TITLE
Store service instance name on provision

### DIFF
--- a/broker/bind_endpoint.go
+++ b/broker/bind_endpoint.go
@@ -29,7 +29,7 @@ func (bkr *Broker) Bind(instanceID string, bindingID string, details brokerapi.B
 }
 
 func (bkr *Broker) bind(instanceID structs.ClusterID, bindingID string, details brokerapi.BindDetails) (brokerapi.BindingResponse, error) {
-	logger := bkr.newLoggingSession("bind", lager.Data{"instanceID": instanceID})
+	logger := bkr.newLoggingSession("bind", lager.Data{"instance-id": instanceID})
 	defer logger.Info("done")
 
 	if err := bkr.assertBindPrecondition(instanceID); err != nil {

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -29,6 +29,7 @@ type Broker struct {
 	scheduler interfaces.Scheduler
 	state     interfaces.State
 	patroni   interfaces.Patroni
+	cf        interfaces.CloudFoundry
 }
 
 // NewBroker is a constructor for a Broker webapp struct
@@ -64,6 +65,14 @@ func NewBroker(config *config.Config) (*Broker, error) {
 	if err != nil {
 		bkr.logger.Error("new-broker.new-router.error", err)
 		return nil, err
+	}
+
+	// Optionally, provisioned services can asynchronously look up service name
+	// to aide disaster recovery/undo-delete/recreate-from-backup by users
+	// that only recall the service instance name they provided Cloud Foundry
+	bkr.cf, err = NewCloudFoundryFromConfig(config.CloudFoundry, bkr.logger)
+	if err != nil {
+		bkr.logger.Error("new-broker.new-cf.error", err)
 	}
 
 	return bkr, nil

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -73,6 +73,8 @@ func NewBroker(config *config.Config) (*Broker, error) {
 	bkr.cf, err = NewCloudFoundryFromConfig(config.CloudFoundry, bkr.logger)
 	if err != nil {
 		bkr.logger.Error("new-broker.new-cf.error", err)
+	} else {
+		bkr.logger.Info("new-broker.new-cf.success", lager.Data{"api-url": config.CloudFoundry.ApiAddress})
 	}
 
 	return bkr, nil

--- a/broker/callbacks_test.go
+++ b/broker/callbacks_test.go
@@ -47,7 +47,7 @@ func TestCallbacks_WriteRecreationData(t *testing.T) {
 	}
 
 	recreationData := &structs.ClusterRecreationData{
-		InstanceID:       "instanceID",
+		InstanceID:       "instance-id",
 		OrganizationGUID: "OrganizationGUID",
 		PlanID:           "PlanID",
 		ServiceID:        "ServiceID",

--- a/broker/cloudfoundry.go
+++ b/broker/cloudfoundry.go
@@ -37,7 +37,7 @@ func (cf *CloudFoundryFromConfig) LookupServiceName(instanceID structs.ClusterID
 		return "", fmt.Errorf("Cannot lookup Service Name for %d without Cloud Foundry credentials", instanceID)
 	}
 	var siResp serviceInstanceResponse
-	r := cf.client.NewRequest("GET", fmt.Sprintf("/v2/service_instances/%d", instanceID))
+	r := cf.client.NewRequest("GET", fmt.Sprintf("/v2/service_instances/%s", instanceID))
 	resp, err := cf.client.DoRequest(r)
 	if err != nil {
 		return "", fmt.Errorf("Error querying service instances %v", err)

--- a/broker/cloudfoundry.go
+++ b/broker/cloudfoundry.go
@@ -33,6 +33,9 @@ func NewCloudFoundryFromConfig(creds config.CloudFoundryCredentials, logger lage
 }
 
 func (cf *CloudFoundryFromConfig) LookupServiceName(instanceID structs.ClusterID) (name string, err error) {
+	if cf.client == nil {
+		return "", fmt.Errorf("Cannot lookup Service Name for %d without Cloud Foundry credentials", instanceID)
+	}
 	var siResp serviceInstanceResponse
 	r := cf.client.NewRequest("GET", fmt.Sprintf("/v2/service_instances/%d", instanceID))
 	resp, err := cf.client.DoRequest(r)

--- a/broker/cloudfoundry.go
+++ b/broker/cloudfoundry.go
@@ -1,0 +1,35 @@
+package broker
+
+import (
+	"fmt"
+
+	"github.com/cloudfoundry-community/go-cfclient"
+	"github.com/dingotiles/dingo-postgresql-broker/broker/structs"
+	"github.com/dingotiles/dingo-postgresql-broker/config"
+	"github.com/pivotal-golang/lager"
+)
+
+type CloudFoundryFromConfig struct {
+	client *cfclient.Client
+}
+
+func NewCloudFoundryFromConfig(creds config.CloudFoundryCredentials, logger lager.Logger) (cf *CloudFoundryFromConfig, err error) {
+	if creds.ApiAddress == "" {
+		return nil, fmt.Errorf("Cloud Foundry credentials not provided")
+	}
+	client, err := cfclient.NewClient(&cfclient.Config{
+		ApiAddress:        creds.ApiAddress,
+		Username:          creds.Username,
+		Password:          creds.Password,
+		SkipSslValidation: creds.SkipSslValidation,
+	})
+	if err != nil {
+		return
+	}
+	cf = &CloudFoundryFromConfig{client: client}
+	return
+}
+
+func (cf *CloudFoundryFromConfig) LookupServiceName(structs.ClusterID) (serviceInstanceName string, err error) {
+	return
+}

--- a/broker/deprovision_endpoint.go
+++ b/broker/deprovision_endpoint.go
@@ -15,7 +15,7 @@ func (bkr *Broker) Deprovision(instanceID string, details brokerapi.DeprovisionD
 }
 
 func (bkr *Broker) deprovision(instanceID structs.ClusterID, details brokerapi.DeprovisionDetails, acceptsIncomplete bool) (async bool, err error) {
-	logger := bkr.newLoggingSession("deprovision", lager.Data{"instanceID": instanceID})
+	logger := bkr.newLoggingSession("deprovision", lager.Data{"instance-id": instanceID})
 	defer logger.Info("done")
 
 	if err = bkr.assertDeprovisionPrecondition(instanceID, details); err != nil {

--- a/broker/interfaces/interfaces.go
+++ b/broker/interfaces/interfaces.go
@@ -47,5 +47,5 @@ type Patroni interface {
 }
 
 type CloudFoundry interface {
-	LookupServiceName(structs.ClusterID) (serviceInstanceName string, err error)
+	LookupServiceName(instanceID structs.ClusterID) (name string, err error)
 }

--- a/broker/interfaces/interfaces.go
+++ b/broker/interfaces/interfaces.go
@@ -45,3 +45,7 @@ type Patroni interface {
 	WaitForAllMembers(instanceID structs.ClusterID, expectedNodeCount int) error
 	WaitForLeader(structs.ClusterID) error
 }
+
+type CloudFoundry interface {
+	LookupServiceName(structs.ClusterID) (serviceInstanceName string, err error)
+}

--- a/broker/last_operation_endpoint.go
+++ b/broker/last_operation_endpoint.go
@@ -18,7 +18,7 @@ func (bkr *Broker) LastOperation(instanceID string) (resp brokerapi.LastOperatio
 }
 
 func (bkr *Broker) lastOperation(instanceID structs.ClusterID) (resp brokerapi.LastOperationResponse, err error) {
-	logger := bkr.newLoggingSession("last-opration", lager.Data{"instanceID": instanceID})
+	logger := bkr.newLoggingSession("last-opration", lager.Data{"instance-id": instanceID})
 	defer logger.Info("done")
 
 	clusterState, err := bkr.state.LoadCluster(instanceID)

--- a/broker/provision_endpoint.go
+++ b/broker/provision_endpoint.go
@@ -49,15 +49,14 @@ func (bkr *Broker) provision(instanceID structs.ClusterID, details brokerapi.Pro
 	// Continue processing in background
 	// TODO: if error, store it into etcd; and last_operation_endpoint should look for errors first
 	go func() {
-		err := bkr.scheduler.RunCluster(clusterModel, features)
-		if err != nil {
+		if err := bkr.scheduler.RunCluster(clusterModel, features); err != nil {
 			logger.Error("run-cluster", err)
 			return
 		}
 
-		err = bkr.router.AssignPortToCluster(clusterModel.InstanceID(), port)
-		if err != nil {
+		if err := bkr.router.AssignPortToCluster(clusterModel.InstanceID(), port); err != nil {
 			logger.Error("assign-port", err)
+			return
 		}
 	}()
 	return resp, true, err

--- a/broker/provision_endpoint.go
+++ b/broker/provision_endpoint.go
@@ -20,7 +20,7 @@ func (bkr *Broker) provision(instanceID structs.ClusterID, details brokerapi.Pro
 		return bkr.Recreate(instanceID, details, acceptsIncomplete)
 	}
 
-	logger := bkr.newLoggingSession("provision", lager.Data{"instanceID": instanceID})
+	logger := bkr.newLoggingSession("provision", lager.Data{"instance-id": instanceID})
 	defer logger.Info("done")
 
 	features, err := structs.ClusterFeaturesFromParameters(details.Parameters)

--- a/broker/provision_endpoint.go
+++ b/broker/provision_endpoint.go
@@ -14,6 +14,7 @@ import (
 func (bkr *Broker) Provision(instanceID string, details brokerapi.ProvisionDetails, acceptsIncomplete bool) (resp brokerapi.ProvisioningResponse, async bool, err error) {
 	return bkr.provision(structs.ClusterID(instanceID), details, acceptsIncomplete)
 }
+
 func (bkr *Broker) provision(instanceID structs.ClusterID, details brokerapi.ProvisionDetails, acceptsIncomplete bool) (resp brokerapi.ProvisioningResponse, async bool, err error) {
 	if details.ServiceID == "" && details.PlanID == "" {
 		return bkr.Recreate(instanceID, details, acceptsIncomplete)
@@ -54,7 +55,7 @@ func (bkr *Broker) provision(instanceID structs.ClusterID, details brokerapi.Pro
 			return
 		}
 
-		if err := bkr.router.AssignPortToCluster(clusterModel.InstanceID(), port); err != nil {
+		if err := bkr.router.AssignPortToCluster(instanceID, port); err != nil {
 			logger.Error("assign-port", err)
 			return
 		}
@@ -66,7 +67,7 @@ func (bkr *Broker) provision(instanceID structs.ClusterID, details brokerapi.Pro
 		// If operation fails, that's temporarily unfortunate but might be due to credentials
 		// not yet having SpaceDeveloper role for the Space being used.
 		if bkr.cf != nil {
-			serviceInstanceName, err := bkr.cf.LookupServiceName(clusterModel.InstanceID())
+			serviceInstanceName, err := bkr.cf.LookupServiceName(instanceID)
 			if err != nil {
 				logger.Error("lookup-service-name.error", err,
 					lager.Data{"action-required": "Fix issue and run errand/script to update clusterdata backups to include service names"})

--- a/broker/structs/structs.go
+++ b/broker/structs/structs.go
@@ -42,6 +42,7 @@ type ClusterState struct {
 	AllocatedPort        int                 `json:"allocated_port"`
 	Nodes                []*Node             `json:"nodes"`
 	SchedulingInfo       SchedulingInfo      `json:"info"`
+	ServiceInstanceName  string              `json:"service_instance_name"`
 }
 
 type SchedulingInfo struct {

--- a/broker/structs/structs.go
+++ b/broker/structs/structs.go
@@ -19,6 +19,7 @@ type SchedulingStatus string
 type ClusterID string
 
 type ClusterRecreationData struct {
+	ServiceInstanceName  string              `json:"service_instance_name"`
 	InstanceID           ClusterID           `json:"instance_id"`
 	ServiceID            string              `json:"service_id"`
 	PlanID               string              `json:"plan_id"`
@@ -58,6 +59,7 @@ func (c *ClusterState) NodeCount() int {
 
 func (c *ClusterState) RecreationData() *ClusterRecreationData {
 	return &ClusterRecreationData{
+		ServiceInstanceName:  c.ServiceInstanceName,
 		InstanceID:           c.InstanceID,
 		ServiceID:            c.ServiceID,
 		PlanID:               c.PlanID,

--- a/broker/unbind_endpoint.go
+++ b/broker/unbind_endpoint.go
@@ -7,7 +7,7 @@ import (
 
 // Unbind to remove access to service instance
 func (bkr *Broker) Unbind(instanceID string, bindingID string, details brokerapi.UnbindDetails) error {
-	logger := bkr.newLoggingSession("unbind", lager.Data{"instanceID": instanceID})
+	logger := bkr.newLoggingSession("unbind", lager.Data{"instance-id": instanceID})
 	defer logger.Info("done")
 	return nil
 }

--- a/broker/update_endpoint.go
+++ b/broker/update_endpoint.go
@@ -14,7 +14,7 @@ func (bkr *Broker) Update(instanceID string, updateDetails brokerapi.UpdateDetai
 	return bkr.update(structs.ClusterID(instanceID), updateDetails, acceptsIncomplete)
 }
 func (bkr *Broker) update(instanceID structs.ClusterID, updateDetails brokerapi.UpdateDetails, acceptsIncomplete bool) (async bool, err error) {
-	logger := bkr.newLoggingSession("update", lager.Data{"instanceID": instanceID})
+	logger := bkr.newLoggingSession("update", lager.Data{"instance-id": instanceID})
 	defer logger.Info("done")
 
 	features, err := structs.ClusterFeaturesFromParameters(updateDetails.Parameters)

--- a/config/config.go
+++ b/config/config.go
@@ -12,12 +12,13 @@ import (
 
 // Config is the brokers configuration
 type Config struct {
-	Broker    Broker            `yaml:"broker"`
-	Cells     []*Cell           `yaml:"cells"`
-	Etcd      Etcd              `yaml:"etcd"`
-	Callbacks Callbacks         `yaml:"callbacks"`
-	Catalog   brokerapi.Catalog `yaml:"catalog"`
-	Scheduler Scheduler
+	Broker       Broker                  `yaml:"broker"`
+	Cells        []*Cell                 `yaml:"cells"`
+	Etcd         Etcd                    `yaml:"etcd"`
+	Callbacks    Callbacks               `yaml:"callbacks"`
+	Catalog      brokerapi.Catalog       `yaml:"catalog"`
+	Scheduler    Scheduler               `yaml:"scheduler"`
+	CloudFoundry CloudFoundryCredentials `yaml:"cf"`
 }
 
 func (cfg *Config) SupportsClusterDataBackup() bool {
@@ -50,6 +51,15 @@ type Cell struct {
 // KVStore describes the KV store used by all the components
 type Etcd struct {
 	Machines []string `yaml:"machines"`
+}
+
+// CloudFoundryCredentials describes credentials for looking up service instance info/name
+// Requires SpaceDeveloper access to all Spaces for which access is enabled.
+type CloudFoundryCredentials struct {
+	ApiAddress        string `yaml:"api"`
+	Username          string `yaml:"username"`
+	Password          string `yaml:"password"`
+	SkipSslValidation bool   `yaml:"skip_ssl_validation"`
 }
 
 // Callbacks allows plug'n'play scripts to be run when events have completed

--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,7 @@ type Etcd struct {
 // CloudFoundryCredentials describes credentials for looking up service instance info/name
 // Requires SpaceDeveloper access to all Spaces for which access is enabled.
 type CloudFoundryCredentials struct {
-	ApiAddress        string `yaml:"api"`
+	ApiAddress        string `yaml:"api_endpoint"`
 	Username          string `yaml:"username"`
 	Password          string `yaml:"password"`
 	SkipSslValidation bool   `yaml:"skip_ssl_validation"`

--- a/config/config.go
+++ b/config/config.go
@@ -56,7 +56,7 @@ type Etcd struct {
 // CloudFoundryCredentials describes credentials for looking up service instance info/name
 // Requires SpaceDeveloper access to all Spaces for which access is enabled.
 type CloudFoundryCredentials struct {
-	ApiAddress        string `yaml:"api_endpoint"`
+	ApiAddress        string `yaml:"api_url"`
 	Username          string `yaml:"username"`
 	Password          string `yaml:"password"`
 	SkipSslValidation bool   `yaml:"skip_ssl_validation"`

--- a/demo/bosh-lite.example.yml
+++ b/demo/bosh-lite.example.yml
@@ -25,7 +25,7 @@ callbacks:
   clusterdata_restore: {cmd: echo, args: ['{"instance_id":"TESTID-1458690055","service_id":"beb5973c-e1b2-11e5-a736-c7c0b526363d","plan_id":"b96d0936-e423-11e5-accb-93d374e93368","organization_guid":"","space_guid":"","parameters":null,"node_count":1,"node_size":20,"allocated_port":"33000"}']}
 
 cf:
-  api: https://api.10-58-111-48.sslip.io
+  api_endpoint: https://api.10-58-111-48.sslip.io
   username: admin
   password: admin
   skip_ssl_validation: true

--- a/demo/bosh-lite.example.yml
+++ b/demo/bosh-lite.example.yml
@@ -24,6 +24,12 @@ callbacks:
   clusterdata_backup: {cmd: jq, args: ["-r", "."]}
   clusterdata_restore: {cmd: echo, args: ['{"instance_id":"TESTID-1458690055","service_id":"beb5973c-e1b2-11e5-a736-c7c0b526363d","plan_id":"b96d0936-e423-11e5-accb-93d374e93368","organization_guid":"","space_guid":"","parameters":null,"node_count":1,"node_size":20,"allocated_port":"33000"}']}
 
+cf:
+  api: https://api.10-58-111-48.sslip.io
+  username: admin
+  password: admin
+  skip_ssl_validation: true
+
 catalog:
   services:
     - name: postgresql95

--- a/demo/bosh-lite.example.yml
+++ b/demo/bosh-lite.example.yml
@@ -25,7 +25,7 @@ callbacks:
   clusterdata_restore: {cmd: echo, args: ['{"instance_id":"TESTID-1458690055","service_id":"beb5973c-e1b2-11e5-a736-c7c0b526363d","plan_id":"b96d0936-e423-11e5-accb-93d374e93368","organization_guid":"","space_guid":"","parameters":null,"node_count":1,"node_size":20,"allocated_port":"33000"}']}
 
 cf:
-  api_endpoint: https://api.10-58-111-48.sslip.io
+  api_url: https://api.10-58-111-48.sslip.io
   username: admin
   password: admin
   skip_ssl_validation: true

--- a/patroni/patroni.go
+++ b/patroni/patroni.go
@@ -137,12 +137,12 @@ func (p *Patroni) WaitForMember(instanceID structs.ClusterID, memberID string) e
 // TODO: prove list of member IDs that cannot be member OR that can be member
 // This will ensure that success isn't for an ex-leader that hasn't died yet
 func (p *Patroni) leaderRunning(instanceID structs.ClusterID) bool {
-	p.logger.Info("check-leader.find-leader", lager.Data{"instanceID": instanceID})
+	p.logger.Info("check-leader.find-leader", lager.Data{"instance-id": instanceID})
 	leaderID, err := p.ClusterLeader(instanceID)
 	if err != nil {
 		return false
 	}
-	p.logger.Info("check-leader.load-member", lager.Data{"instanceID": instanceID, "leader": leaderID})
+	p.logger.Info("check-leader.load-member", lager.Data{"instance-id": instanceID, "leader": leaderID})
 	leader, err := p.loadMember(instanceID, leaderID)
 	if err != nil {
 		return false

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/.gitignore
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/.gitignore
@@ -1,0 +1,26 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+_workspace
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/.travis.yml
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/.travis.yml
@@ -1,0 +1,2 @@
+language: go
+sudo: false

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/LICENSE
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2015 Long Nguyen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/README.md
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/README.md
@@ -1,0 +1,45 @@
+# go-cfclient
+
+### Overview
+
+[![Build Status](https://img.shields.io/travis/cloudfoundry-community/go-cfclient.svg)](https://travis-ci.org/cloudfoundry-community/go-cfclient) [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/cloudfoundry-community/go-cfclient)
+
+`cfclient` is a package to assist you in writing apps that need information out of [Cloud Foundry](http://cloudfoundry.org). It provides functions and structures to retrieve
+
+
+### Usage
+
+```
+go get github.com/cloudfoundry-community/go-cfclient
+```
+
+Some example code:
+
+```go
+package main
+
+import (
+	"github.com/cloudfoundry-community/go-cfclient"
+)
+
+func main() {
+  c := &Config{
+    ApiAddress:   "https://api.10.244.0.34.xip.io",
+    Username:     "admin",
+    Password:     "admin",
+  }
+  client, _ := NewClient(c)
+  apps, _ := client.ListApps()
+  fmt.Println(apps)
+}
+```
+
+### Developing & Contributing
+
+You can use Godep to restor the dependency
+Tested with go1.5.3
+```bash
+godep go build
+```
+
+Pull requests welcomed. Please ensure you make your changes in a branch off of the `develop` branch, not the `master` branch.

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/appevents.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/appevents.go
@@ -1,0 +1,163 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"time"
+)
+
+const (
+	//AppCrash app.crash event const
+	AppCrash = "app.crash"
+	//AppStart audit.app.start event const
+	AppStart = "audit.app.start"
+	//AppStop audit.app.stop event const
+	AppStop = "audit.app.stop"
+	//AppUpdate audit.app.update event const
+	AppUpdate = "audit.app.update"
+	//AppCreate audit.app.create event const
+	AppCreate = "audit.app.create"
+	//AppDelete audit.app.delete-request event const
+	AppDelete = "audit.app.delete-request"
+	//AppSSHAuth audit.app.ssh-authorized event const
+	AppSSHAuth = "audit.app.ssh-authorized"
+	//AppSSHUnauth audit.app.ssh-unauthorized event const
+	AppSSHUnauth = "audit.app.ssh-unauthorized"
+	//FilterTimestamp const for query filter timestamp
+	FilterTimestamp = "timestamp"
+	//FilterActee const for query filter actee
+	FilterActee = "actee"
+)
+
+//ValidOperators const for all valid operators in a query
+var ValidOperators = []string{":", ">=", "<=", "<", ">", "IN"}
+
+// AppEventResponse the entire response
+type AppEventResponse struct {
+	Results   int                `json:"total_results"`
+	Pages     int                `json:"total_pages"`
+	PrevURL   string             `json:"prev_url"`
+	NextURL   string             `json:"next_url"`
+	Resources []AppEventResource `json:"resources"`
+}
+
+// AppEventResource the event resources
+type AppEventResource struct {
+	Meta   Meta           `json:"metadata"`
+	Entity AppEventEntity `json:"entity"`
+}
+
+//AppEventQuery a struct for defining queries like 'q=filter>value' or 'q=filter IN a,b,c'
+type AppEventQuery struct {
+	Filter   string
+	Operator string
+	Value    string
+}
+
+// The AppEventEntity the actual app event body
+type AppEventEntity struct {
+	//EventTypes are app.crash, audit.app.start, audit.app.stop, audit.app.update, audit.app.create, audit.app.delete-request
+	EventType string `json:"type"`
+	//The GUID of the actor.
+	Actor string `json:"actor"`
+	//The actor type, user or app
+	ActorType string `json:"actor_type"`
+	//The name of the actor.
+	ActorName string `json:"actor_name"`
+	//The GUID of the actee.
+	Actee string `json:"actee"`
+	//The actee type, space, app or v3-app
+	ActeeType string `json:"actee_type"`
+	//The name of the actee.
+	ActeeName string `json:"actee_name"`
+	//Timestamp format "2016-02-26T13:29:44Z". The event creation time.
+	Timestamp time.Time `json:"timestamp"`
+	MetaData  struct {
+		Request struct {
+			Name              string  `json:"name,omitempty"`
+			Instances         float64 `json:"instances,omitempty"`
+			State             string  `json:"state,omitempty"`
+			Memory            float64 `json:"memory,omitempty"`
+			EnvironmentVars   string  `json:"environment_json,omitempty"`
+			DockerCredentials string  `json:"docker_credentials_json,omitempty"`
+			//audit.app.create event fields
+			Console            bool    `json:"console,omitempty"`
+			Buildpack          string  `json:"buildpack,omitempty"`
+			Space              string  `json:"space_guid,omitempty"`
+			HealthcheckType    string  `json:"health_check_type,omitempty"`
+			HealthcheckTimeout float64 `json:"health_check_timeout,omitempty"`
+			Production         bool    `json:"production,omitempty"`
+			//app.crash event fields
+			Index           float64 `json:"index,omitempty"`
+			ExitStatus      string  `json:"exit_status,omitempty"`
+			ExitDescription string  `json:"exit_description,omitempty"`
+			ExitReason      string  `json:"reason,omitempty"`
+		} `json:"request"`
+	} `json:"metadata"`
+}
+
+// ListAppEvents returns all app events based on eventType
+func (c *Client) ListAppEvents(eventType string) ([]AppEventEntity, error) {
+	return c.ListAppEventsByQuery(eventType, nil)
+}
+
+// ListAppEventsByQuery returns all app events based on eventType and queries
+func (c *Client) ListAppEventsByQuery(eventType string, queries []AppEventQuery) ([]AppEventEntity, error) {
+
+	if eventType != AppCrash && eventType != AppStart && eventType != AppStop && eventType != AppUpdate && eventType != AppCreate &&
+		eventType != AppDelete && eventType != AppSSHAuth && eventType != AppSSHUnauth {
+		return nil, errors.New("Unsupported app event type " + eventType)
+	}
+
+	var query = "/v2/events?q=type:" + eventType
+	//adding the additional queries
+	if queries != nil && len(queries) > 0 {
+		for _, eventQuery := range queries {
+			if eventQuery.Filter != FilterTimestamp && eventQuery.Filter != FilterActee {
+				return nil, errors.New("Unsupported query filter type " + eventQuery.Filter)
+			}
+			if !stringInSlice(eventQuery.Operator, ValidOperators) {
+				return nil, errors.New("Unsupported query operator type " + eventQuery.Operator)
+			}
+			query += "&q=" + eventQuery.Filter + eventQuery.Operator + eventQuery.Value
+		}
+	}
+
+	requ := c.NewRequest("GET", query)
+
+	resp, err := c.DoRequest(requ)
+	if err != nil {
+		return nil, err
+	}
+
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, errors.New(string(resBody[:]))
+	}
+
+	var eventResponse AppEventResponse
+	err = json.Unmarshal(resBody, &eventResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	eventsLen := len(eventResponse.Resources)
+	events := make([]AppEventEntity, eventsLen)
+	for i := 0; i < eventsLen; i++ {
+		events[i] = eventResponse.Resources[i].Entity
+	}
+	return events, nil
+}
+
+func stringInSlice(str string, list []string) bool {
+	for _, v := range list {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/apps.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/apps.go
@@ -1,0 +1,150 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+)
+
+type AppResponse struct {
+	Count     int           `json:"total_results"`
+	Pages     int           `json:"total_pages"`
+	NextUrl   string        `json:"next_url"`
+	Resources []AppResource `json:"resources"`
+}
+
+type AppResource struct {
+	Meta   Meta `json:"metadata"`
+	Entity App  `json:"entity"`
+}
+
+type App struct {
+	Guid        string                 `json:"guid"`
+	Name        string                 `json:"name"`
+	Environment map[string]interface{} `json:"environment_json"`
+	SpaceURL    string                 `json:"space_url"`
+	SpaceData   SpaceResource          `json:"space"`
+	c           *Client
+}
+
+type AppInstance struct {
+	State string `json:"state"`
+}
+
+func (a *App) Space() (Space, error) {
+	var spaceResource SpaceResource
+	r := a.c.NewRequest("GET", a.SpaceURL)
+	resp, err := a.c.DoRequest(r)
+	if err != nil {
+		return Space{}, fmt.Errorf("Error requesting space: %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading space request: %v", err)
+	}
+
+	err = json.Unmarshal(resBody, &spaceResource)
+	if err != nil {
+		return Space{}, fmt.Errorf("Error unmarshaling space: %v", err)
+	}
+	spaceResource.Entity.Guid = spaceResource.Meta.Guid
+	spaceResource.Entity.c = a.c
+	return spaceResource.Entity, nil
+}
+
+func (c *Client) ListApps() ([]App, error) {
+	var apps []App
+
+	requestUrl := "/v2/apps?inline-relations-depth=2"
+	for {
+		var appResp AppResponse
+		r := c.NewRequest("GET", requestUrl)
+		resp, err := c.DoRequest(r)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error requesting apps %v", err)
+		}
+		resBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading app request %v", resBody)
+		}
+
+		err = json.Unmarshal(resBody, &appResp)
+		if err != nil {
+			return nil, fmt.Errorf("Error unmarshaling app %v", err)
+		}
+
+		for _, app := range appResp.Resources {
+			app.Entity.Guid = app.Meta.Guid
+			app.Entity.SpaceData.Entity.Guid = app.Entity.SpaceData.Meta.Guid
+			app.Entity.SpaceData.Entity.OrgData.Entity.Guid = app.Entity.SpaceData.Entity.OrgData.Meta.Guid
+			app.Entity.c = c
+			apps = append(apps, app.Entity)
+		}
+
+		requestUrl = appResp.NextUrl
+		if requestUrl == "" {
+			break
+		}
+	}
+	return apps, nil
+}
+
+func (c *Client) GetAppInstances(guid string) (map[string]AppInstance, error) {
+	var appInstances map[string]AppInstance
+
+	requestURL := fmt.Sprintf("/v2/apps/%s/instances", guid)
+	r := c.NewRequest("GET", requestURL)
+	resp, err := c.DoRequest(r)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("Error requesting app instances %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading app instances %v", err)
+	}
+	err = json.Unmarshal(resBody, &appInstances)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshalling app instances %v", err)
+	}
+	return appInstances, nil
+}
+
+func (c *Client) KillAppInstance(guid string, index string) error {
+	requestURL := fmt.Sprintf("/v2/apps/%s/instances/%s", guid, index)
+	r := c.NewRequest("DELETE", requestURL)
+	resp, err := c.DoRequest(r)
+	defer resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("Error stopping app %s at index %s", guid, index)
+	}
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("Error stopping app %s at index %s", guid, index)
+	}
+	return nil
+}
+
+func (c *Client) AppByGuid(guid string) (App, error) {
+	var appResource AppResource
+	r := c.NewRequest("GET", "/v2/apps/"+guid+"?inline-relations-depth=2")
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return App{}, fmt.Errorf("Error requesting apps: %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading app request %v", resBody)
+	}
+
+	err = json.Unmarshal(resBody, &appResource)
+	if err != nil {
+		return App{}, fmt.Errorf("Error unmarshaling app: %v", err)
+	}
+	appResource.Entity.Guid = appResource.Meta.Guid
+	appResource.Entity.SpaceData.Entity.Guid = appResource.Entity.SpaceData.Meta.Guid
+	appResource.Entity.SpaceData.Entity.OrgData.Entity.Guid = appResource.Entity.SpaceData.Entity.OrgData.Meta.Guid
+	appResource.Entity.c = c
+	return appResource.Entity, nil
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/client.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/client.go
@@ -1,0 +1,214 @@
+package cfclient
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+)
+
+//Client used to communicate with Cloud Foundry
+type Client struct {
+	config   Config
+	Endpoint Endpoint
+}
+
+type Endpoint struct {
+	DopplerEndpoint string `json:"doppler_logging_endpoint"`
+	LoggingEndpoint string `json:"logging_endpoint"`
+	AuthEndpoint    string `json:"authorization_endpoint"`
+	TokenEndpoint   string `json:"token_endpoint"`
+}
+
+//Config is used to configure the creation of a client
+type Config struct {
+	ApiAddress        string
+	Username          string
+	Password          string
+	SkipSslValidation bool
+	HttpClient        *http.Client
+	Token             string
+	TokenSource       oauth2.TokenSource
+}
+
+// request is used to help build up a request
+type request struct {
+	method string
+	url    string
+	params url.Values
+	body   io.Reader
+	obj    interface{}
+}
+
+//DefaultConfig configuration for client
+//Keep LoginAdress for backward compatibility
+//Need to be remove in close future
+func DefaultConfig() *Config {
+	return &Config{
+		ApiAddress:        "http://api.bosh-lite.com",
+		Username:          "admin",
+		Password:          "admin",
+		Token:             "",
+		SkipSslValidation: false,
+		HttpClient:        http.DefaultClient,
+	}
+}
+
+func DefaultEndpoint() *Endpoint {
+	return &Endpoint{
+		DopplerEndpoint: "wss://doppler.10.244.0.34.xip.io:443",
+		LoggingEndpoint: "wss://loggregator.10.244.0.34.xip.io:443",
+		TokenEndpoint:   "https://uaa.10.244.0.34.xip.io",
+		AuthEndpoint:    "https://login.10.244.0.34.xip.io",
+	}
+}
+
+// NewClient returns a new client
+func NewClient(config *Config) (client *Client, err error) {
+	// bootstrap the config
+	defConfig := DefaultConfig()
+
+	if len(config.ApiAddress) == 0 {
+		config.ApiAddress = defConfig.ApiAddress
+	}
+
+	if len(config.Username) == 0 {
+		config.Username = defConfig.Username
+	}
+
+	if len(config.Password) == 0 {
+		config.Password = defConfig.Password
+	}
+
+	if len(config.Token) == 0 {
+		config.Token = defConfig.Token
+	}
+
+	ctx := oauth2.NoContext
+	if config.SkipSslValidation == false {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, defConfig.HttpClient)
+	} else {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Transport: tr})
+	}
+
+	endpoint, err := getInfo(config.ApiAddress, oauth2.NewClient(ctx, nil))
+
+	if err != nil {
+		return nil, fmt.Errorf("Could not get api /v2/info: %v", err)
+	}
+
+	authConfig := &oauth2.Config{
+		ClientID: "cf",
+		Scopes:   []string{""},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  endpoint.AuthEndpoint + "/oauth/auth",
+			TokenURL: endpoint.TokenEndpoint + "/oauth/token",
+		},
+	}
+
+	token, err := authConfig.PasswordCredentialsToken(ctx, config.Username, config.Password)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error getting token: %v", err)
+	}
+
+	config.TokenSource = authConfig.TokenSource(ctx, token)
+	config.HttpClient = oauth2.NewClient(ctx, config.TokenSource)
+
+	client = &Client{
+		config:   *config,
+		Endpoint: *endpoint,
+	}
+	return client, nil
+}
+
+func getInfo(api string, httpClient *http.Client) (*Endpoint, error) {
+	var endpoint Endpoint
+
+	if api == "" {
+		return DefaultEndpoint(), nil
+	}
+
+	resp, err := httpClient.Get(api + "/v2/info")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = decodeBody(resp, &endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &endpoint, err
+}
+
+// NewRequest is used to create a new request
+func (c *Client) NewRequest(method, path string) *request {
+	r := &request{
+		method: method,
+		url:    c.config.ApiAddress + path,
+		params: make(map[string][]string),
+	}
+	return r
+}
+
+// DoRequest runs a request with our client
+func (c *Client) DoRequest(r *request) (*http.Response, error) {
+	req, err := r.toHTTP()
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.config.HttpClient.Do(req)
+	return resp, err
+}
+
+// toHTTP converts the request to an HTTP request
+func (r *request) toHTTP() (*http.Request, error) {
+
+	// Check if we should encode the body
+	if r.body == nil && r.obj != nil {
+		b, err := encodeBody(r.obj)
+		if err != nil {
+			return nil, err
+		}
+		r.body = b
+	}
+
+	// Create the HTTP request
+	return http.NewRequest(r.method, r.url, r.body)
+}
+
+// decodeBody is used to JSON decode a body
+func decodeBody(resp *http.Response, out interface{}) error {
+	defer resp.Body.Close()
+	dec := json.NewDecoder(resp.Body)
+	return dec.Decode(out)
+}
+
+// encodeBody is used to encode a request body
+func encodeBody(obj interface{}) (io.Reader, error) {
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(obj); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (c *Client) GetToken() (string, error) {
+	token, err := c.config.TokenSource.Token()
+	if err != nil {
+		return "", fmt.Errorf("Error getting bearer token: %v", err)
+	}
+	return "bearer " + token.AccessToken, nil
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/orgs.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/orgs.go
@@ -1,0 +1,77 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+)
+
+type OrgResponse struct {
+	Count     int           `json:"total_results"`
+	Pages     int           `json:"total_pages"`
+	Resources []OrgResource `json:"resources"`
+}
+
+type OrgResource struct {
+	Meta   Meta `json:"metadata"`
+	Entity Org  `json:"entity"`
+}
+
+type Org struct {
+	Guid string `json:"guid"`
+	Name string `json:"name"`
+	c    *Client
+}
+
+func (c *Client) ListOrgs() ([]Org, error) {
+	var orgs []Org
+	var orgResp OrgResponse
+	r := c.NewRequest("GET", "/v2/organizations")
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return nil, fmt.Errorf("Error requesting organizations %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading organization request %v", resBody)
+	}
+
+	err = json.Unmarshal(resBody, &orgResp)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshalling organization %v", err)
+	}
+	for _, org := range orgResp.Resources {
+		org.Entity.Guid = org.Meta.Guid
+		org.Entity.c = c
+		orgs = append(orgs, org.Entity)
+	}
+	return orgs, nil
+}
+
+func (c *Client) OrgSpaces(guid string) ([]Space, error) {
+	var spaces []Space
+	var spaceResp SpaceResponse
+	path := fmt.Sprintf("/v2/organizations/%s/spaces", guid)
+	r := c.NewRequest("GET", path)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return nil, fmt.Errorf("Error requesting space %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("Error reading space request %v", resBody)
+	}
+
+	err = json.Unmarshal(resBody, &spaceResp)
+	if err != nil {
+		return nil, fmt.Errorf("Error space organization %v", err)
+	}
+	for _, space := range spaceResp.Resources {
+		space.Entity.Guid = space.Meta.Guid
+		spaces = append(spaces, space.Entity)
+	}
+
+	return spaces, nil
+
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/secgroups.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/secgroups.go
@@ -1,0 +1,239 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+)
+
+type SecGroupResponse struct {
+	Count     int                `json:"total_results"`
+	Pages     int                `json:"total_pages"`
+	NextUrl   string             `json:"next_url"`
+	Resources []SecGroupResource `json:"resources"`
+}
+
+type SecGroupResource struct {
+	Meta   Meta     `json:"metadata"`
+	Entity SecGroup `json:"entity"`
+}
+
+type SecGroup struct {
+	Guid       string          `json:"guid"`
+	Name       string          `json:"name"`
+	Rules      []SecGroupRule  `json:"rules"`
+	Running    bool            `json:"running_default"`
+	Staging    bool            `json:"staging_default"`
+	SpacesURL  string          `json:"spaces_url"`
+	SpacesData []SpaceResource `json:"spaces"`
+	c          *Client
+}
+
+type SecGroupRule struct {
+	Protocol    string `json:"protocol"`
+	Type        string `json:"type,omitempty"`        //ICMP type. Only valid if Protocol=="icmp"
+	Ports       string `json:"ports"`                 //e.g. "4000-5000,9142"
+	Destination string `json:"destination"`           //CIDR Format
+	Description string `json:"description,omitempty"` //Optional description
+	Log         bool   `json:"log,omitempty"`         //If true, log this rule
+}
+
+func (c *Client) ListSecGroups() (secGroups []SecGroup, err error) {
+	requestURL := "/v2/security_groups?inline-relations-depth=1"
+	for requestURL != "" {
+		var secGroupResp SecGroupResponse
+		r := c.NewRequest("GET", requestURL)
+		resp, err := c.DoRequest(r)
+
+		if err != nil {
+			return nil, fmt.Errorf("Error requesting sec groups %v", err)
+		}
+		resBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("Error reading sec group request %v", string(resBody))
+		}
+
+		err = json.Unmarshal(resBody, &secGroupResp)
+		if err != nil {
+			return nil, fmt.Errorf("Error unmarshaling sec group %v", err)
+		}
+
+		for _, secGroup := range secGroupResp.Resources {
+			secGroup.Entity.Guid = secGroup.Meta.Guid
+			secGroup.Entity.c = c
+			for i, space := range secGroup.Entity.SpacesData {
+				space.Entity.Guid = space.Meta.Guid
+				secGroup.Entity.SpacesData[i] = space
+			}
+			if len(secGroup.Entity.SpacesData) == 0 {
+				spaces, err := secGroup.Entity.ListSpaceResources()
+				if err != nil {
+					return nil, err
+				}
+				for _, space := range spaces {
+					secGroup.Entity.SpacesData = append(secGroup.Entity.SpacesData, space)
+				}
+			}
+			secGroups = append(secGroups, secGroup.Entity)
+		}
+
+		requestURL = secGroupResp.NextUrl
+		resp.Body.Close()
+	}
+	return secGroups, nil
+}
+
+func (secGroup *SecGroup) ListSpaceResources() ([]SpaceResource, error) {
+	var spaceResources []SpaceResource
+	requestURL := secGroup.SpacesURL
+	for requestURL != "" {
+		spaceResp, err := secGroup.c.getSpaceResponse(requestURL)
+		if err != nil {
+			return []SpaceResource{}, err
+		}
+		for i, spaceRes := range spaceResp.Resources {
+			spaceRes.Entity.Guid = spaceRes.Meta.Guid
+			spaceResp.Resources[i] = spaceRes
+		}
+		spaceResources = append(spaceResources, spaceResp.Resources...)
+		requestURL = spaceResp.NextUrl
+	}
+	return spaceResources, nil
+}
+
+/*
+CreateSecGroup contacts the CF endpoint for creating a new security group.
+name: the name to give to the created security group
+rules: A slice of rule objects that describe the rules that this security group enforces.
+	This can technically be nil or an empty slice - we won't judge you
+spaceGuids: The security group will be associated with the spaces specified by the contents of this slice.
+	If nil, the security group will not be associated with any spaces initially.
+*/
+func (c *Client) CreateSecGroup(name string, rules []SecGroupRule, spaceGuids []string) (*SecGroup, error) {
+	return c.secGroupCreateHelper("/v2/security_groups", "POST", name, rules, spaceGuids)
+}
+
+/*
+UpdateSecGroup contacts the CF endpoint to update an existing security group.
+guid: identifies the security group that you would like to update.
+name: the new name to give to the security group
+rules: A slice of rule objects that describe the rules that this security group enforces.
+	If this is left nil, the rules will not be changed.
+spaceGuids: The security group will be associated with the spaces specified by the contents of this slice.
+	If nil, the space associations will not be changed.
+*/
+func (c *Client) UpdateSecGroup(guid, name string, rules []SecGroupRule, spaceGuids []string) (*SecGroup, error) {
+	return c.secGroupCreateHelper("/v2/security_groups/"+guid, "PUT", name, rules, spaceGuids)
+}
+
+/*
+DeleteSecGroup contacts the CF endpoint to delete an existing security group.
+guid: Indentifies the security group to be deleted.
+*/
+func (c *Client) DeleteSecGroup(guid string) error {
+	//Perform the DELETE and check for errors
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/security_groups/%s", guid)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 204 { //204 No Content
+		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+/*
+GetSecGroup contacts the CF endpoint for fetching the info for a particular security group.
+guid: Identifies the security group to fetch information from
+*/
+func (c *Client) GetSecGroup(guid string) (*SecGroup, error) {
+	//Perform the GET and check for errors
+	resp, err := c.DoRequest(c.NewRequest("GET", "/v2/security_groups/"+guid))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	//get the json out of the response body
+	return respBodyToSecGroup(resp.Body, c)
+}
+
+/*
+BindSecGroup contacts the CF endpoint to associate a space with a security group
+secGUID: identifies the security group to add a space to
+spaceGUID: identifies the space to associate
+*/
+func (c *Client) BindSecGroup(secGUID, spaceGUID string) error {
+	//Perform the PUT and check for errors
+	resp, err := c.DoRequest(c.NewRequest("PUT", fmt.Sprintf("/v2/security_groups/%s/spaces/%s", secGUID, spaceGUID)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 201 { //201 Created
+		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+/*
+UnbindSecGroup contacts the CF endpoint to dissociate a space from a security group
+secGUID: identifies the security group to remove a space from
+spaceGUID: identifies the space to dissociate from the security group
+*/
+func (c *Client) UnbindSecGroup(secGUID, spaceGUID string) error {
+	//Perform the DELETE and check for errors
+	resp, err := c.DoRequest(c.NewRequest("DELETE", fmt.Sprintf("/v2/security_groups/%s/spaces/%s", secGUID, spaceGUID)))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 204 { //204 No Content
+		return fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	return nil
+}
+
+//Reads most security group response bodies into a SecGroup object
+func respBodyToSecGroup(body io.ReadCloser, c *Client) (*SecGroup, error) {
+	//get the json from the response body
+	bodyRaw, err := ioutil.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("Could not read response body: %s", err.Error())
+	}
+	jStruct := SecGroupResource{}
+	//make it a SecGroup
+	err = json.Unmarshal([]byte(bodyRaw), &jStruct)
+	if err != nil {
+		return nil, fmt.Errorf(`Could not unmarshal response body as json.
+		body: %s
+		error: %s`, bodyRaw, err.Error())
+	}
+	//pull a few extra fields from other places
+	ret := jStruct.Entity
+	ret.Guid = jStruct.Meta.Guid
+	ret.c = c
+	return &ret, nil
+}
+
+//Create and Update secGroup pretty much do the same thing, so this function abstracts those out.
+func (c *Client) secGroupCreateHelper(url, method, name string, rules []SecGroupRule, spaceGuids []string) (*SecGroup, error) {
+	req := c.NewRequest(method, url)
+	//set up request body
+	req.obj = map[string]interface{}{
+		"name":        name,
+		"rules":       rules,
+		"space_guids": spaceGuids,
+	}
+	//fire off the request and check for problems
+	resp, err := c.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 201 { // Both create and update should give 201 CREATED
+		return nil, fmt.Errorf("CF API returned with status code %d", resp.StatusCode)
+	}
+	//get the json from the response body
+	return respBodyToSecGroup(resp.Body, c)
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/services.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/services.go
@@ -1,0 +1,49 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+type servicesResponse struct {
+	Count     int                `json:"total_results"`
+	Pages     int                `json:"total_pages"`
+	Resources []servicesResource `json:"resources"`
+}
+
+type servicesResource struct {
+	Meta   Meta    `json:"metadata"`
+	Entity Service `json:"entity"`
+}
+
+type Service struct {
+	Guid  string `json:"guid"`
+	Label string `json:"label"`
+	c     *Client
+}
+
+func (c *Client) ListServices() ([]Service, error) {
+	var services []Service
+	var serviceResp servicesResponse
+	r := c.NewRequest("GET", "/v2/services")
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return nil, fmt.Errorf("Error requesting services %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading services request: %v", err)
+	}
+
+	err = json.Unmarshal(resBody, &serviceResp)
+	if err != nil {
+		return nil, fmt.Errorf("Error unmarshaling services %v", err)
+	}
+	for _, service := range serviceResp.Resources {
+		service.Entity.Guid = service.Meta.Guid
+		service.Entity.c = c
+		services = append(services, service.Entity)
+	}
+	return services, nil
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/spaces.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/spaces.go
@@ -1,0 +1,88 @@
+package cfclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+)
+
+type SpaceResponse struct {
+	Count     int             `json:"total_results"`
+	Pages     int             `json:"total_pages"`
+	NextUrl   string          `json:"next_url"`
+	Resources []SpaceResource `json:"resources"`
+}
+
+type SpaceResource struct {
+	Meta   Meta  `json:"metadata"`
+	Entity Space `json:"entity"`
+}
+
+type Space struct {
+	Guid    string      `json:"guid"`
+	Name    string      `json:"name"`
+	OrgURL  string      `json:"organization_url"`
+	OrgData OrgResource `json:"organization"`
+	c       *Client
+}
+
+func (s *Space) Org() (Org, error) {
+	var orgResource OrgResource
+	r := s.c.NewRequest("GET", s.OrgURL)
+	resp, err := s.c.DoRequest(r)
+	if err != nil {
+		return Org{}, fmt.Errorf("Error requesting org %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return Org{}, fmt.Errorf("Error reading org request %v", err)
+	}
+
+	err = json.Unmarshal(resBody, &orgResource)
+	if err != nil {
+		return Org{}, fmt.Errorf("Error unmarshaling org %v", err)
+	}
+	orgResource.Entity.Guid = orgResource.Meta.Guid
+	orgResource.Entity.c = s.c
+	return orgResource.Entity, nil
+}
+
+func (c *Client) ListSpaces() ([]Space, error) {
+	var spaces []Space
+	requestUrl := "/v2/spaces"
+	for {
+		spaceResp, err := c.getSpaceResponse(requestUrl)
+		if err != nil {
+			return []Space{}, err
+		}
+		for _, space := range spaceResp.Resources {
+			space.Entity.Guid = space.Meta.Guid
+			space.Entity.c = c
+			spaces = append(spaces, space.Entity)
+		}
+		requestUrl = spaceResp.NextUrl
+		if requestUrl == "" {
+			break
+		}
+	}
+	return spaces, nil
+}
+
+func (c *Client) getSpaceResponse(requestUrl string) (SpaceResponse, error) {
+	var spaceResp SpaceResponse
+	r := c.NewRequest("GET", requestUrl)
+	resp, err := c.DoRequest(r)
+	if err != nil {
+		return SpaceResponse{}, fmt.Errorf("Error requesting spaces %v", err)
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return SpaceResponse{}, fmt.Errorf("Error reading space request %v", err)
+	}
+	err = json.Unmarshal(resBody, &spaceResp)
+	if err != nil {
+		return SpaceResponse{}, fmt.Errorf("Error unmarshalling space %v", err)
+	}
+	return spaceResp, nil
+}

--- a/vendor/github.com/cloudfoundry-community/go-cfclient/types.go
+++ b/vendor/github.com/cloudfoundry-community/go-cfclient/types.go
@@ -1,0 +1,5 @@
+package cfclient
+
+type Meta struct {
+	Guid string `json:"guid"`
+}

--- a/vendor/golang.org/x/oauth2/.travis.yml
+++ b/vendor/golang.org/x/oauth2/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.3
+  - 1.4
+
+install:
+  - export GOPATH="$HOME/gopath"
+  - mkdir -p "$GOPATH/src/golang.org/x"
+  - mv "$TRAVIS_BUILD_DIR" "$GOPATH/src/golang.org/x/oauth2"
+  - go get -v -t -d golang.org/x/oauth2/...
+
+script:
+  - go test -v golang.org/x/oauth2/...

--- a/vendor/golang.org/x/oauth2/AUTHORS
+++ b/vendor/golang.org/x/oauth2/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/oauth2/CONTRIBUTING.md
+++ b/vendor/golang.org/x/oauth2/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to Go
+
+Go is an open source project.
+
+It is the work of hundreds of contributors. We appreciate your help!
+
+
+## Filing issues
+
+When [filing an issue](https://github.com/golang/oauth2/issues), make sure to answer these five questions:
+
+1. What version of Go are you using (`go version`)?
+2. What operating system and processor architecture are you using?
+3. What did you do?
+4. What did you expect to see?
+5. What did you see instead?
+
+General questions should go to the [golang-nuts mailing list](https://groups.google.com/group/golang-nuts) instead of the issue tracker.
+The gophers there will answer or ask you to file an issue if you've tripped over a bug.
+
+## Contributing code
+
+Please read the [Contribution Guidelines](https://golang.org/doc/contribute.html)
+before sending patches.
+
+**We do not accept GitHub pull requests**
+(we use [Gerrit](https://code.google.com/p/gerrit/) instead for code review).
+
+Unless otherwise noted, the Go source files are distributed under
+the BSD-style license found in the LICENSE file.
+

--- a/vendor/golang.org/x/oauth2/CONTRIBUTORS
+++ b/vendor/golang.org/x/oauth2/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/oauth2/LICENSE
+++ b/vendor/golang.org/x/oauth2/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The oauth2 Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/oauth2/README.md
+++ b/vendor/golang.org/x/oauth2/README.md
@@ -1,0 +1,64 @@
+# OAuth2 for Go
+
+[![Build Status](https://travis-ci.org/golang/oauth2.svg?branch=master)](https://travis-ci.org/golang/oauth2)
+
+oauth2 package contains a client implementation for OAuth 2.0 spec.
+
+## Installation
+
+~~~~
+go get golang.org/x/oauth2
+~~~~
+
+See godoc for further documentation and examples.
+
+* [godoc.org/golang.org/x/oauth2](http://godoc.org/golang.org/x/oauth2)
+* [godoc.org/golang.org/x/oauth2/google](http://godoc.org/golang.org/x/oauth2/google)
+
+
+## App Engine
+
+In change 96e89be (March 2015) we removed the `oauth2.Context2` type in favor
+of the [`context.Context`](https://golang.org/x/net/context#Context) type from
+the `golang.org/x/net/context` package
+
+This means its no longer possible to use the "Classic App Engine"
+`appengine.Context` type with the `oauth2` package. (You're using
+Classic App Engine if you import the package `"appengine"`.)
+
+To work around this, you may use the new `"google.golang.org/appengine"`
+package. This package has almost the same API as the `"appengine"` package,
+but it can be fetched with `go get` and used on "Managed VMs" and well as
+Classic App Engine.
+
+See the [new `appengine` package's readme](https://github.com/golang/appengine#updating-a-go-app-engine-app)
+for information on updating your app.
+
+If you don't want to update your entire app to use the new App Engine packages,
+you may use both sets of packages in parallel, using only the new packages
+with the `oauth2` package.
+
+	import (
+		"golang.org/x/net/context"
+		"golang.org/x/oauth2"
+		"golang.org/x/oauth2/google"
+		newappengine "google.golang.org/appengine"
+		newurlfetch "google.golang.org/appengine/urlfetch"
+
+		"appengine"
+	)
+
+	func handler(w http.ResponseWriter, r *http.Request) {
+		var c appengine.Context = appengine.NewContext(r)
+		c.Infof("Logging a message with the old package")
+
+		var ctx context.Context = newappengine.NewContext(r)
+		client := &http.Client{
+			Transport: &oauth2.Transport{
+				Source: google.AppEngineTokenSource(ctx, "scope"),
+				Base:   &newurlfetch.Transport{Context: ctx},
+			},
+		}
+		client.Get("...")
+	}
+

--- a/vendor/golang.org/x/oauth2/client_appengine.go
+++ b/vendor/golang.org/x/oauth2/client_appengine.go
@@ -1,0 +1,25 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+// App Engine hooks.
+
+package oauth2
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+	"google.golang.org/appengine/urlfetch"
+)
+
+func init() {
+	internal.RegisterContextClientFunc(contextClientAppEngine)
+}
+
+func contextClientAppEngine(ctx context.Context) (*http.Client, error) {
+	return urlfetch.Client(ctx), nil
+}

--- a/vendor/golang.org/x/oauth2/internal/oauth2.go
+++ b/vendor/golang.org/x/oauth2/internal/oauth2.go
@@ -1,0 +1,76 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"bufio"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ParseKey converts the binary contents of a private key file
+// to an *rsa.PrivateKey. It detects whether the private key is in a
+// PEM container or not. If so, it extracts the the private key
+// from PEM container before conversion. It only supports PEM
+// containers with no passphrase.
+func ParseKey(key []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(key)
+	if block != nil {
+		key = block.Bytes
+	}
+	parsedKey, err := x509.ParsePKCS8PrivateKey(key)
+	if err != nil {
+		parsedKey, err = x509.ParsePKCS1PrivateKey(key)
+		if err != nil {
+			return nil, fmt.Errorf("private key should be a PEM or plain PKSC1 or PKCS8; parse error: %v", err)
+		}
+	}
+	parsed, ok := parsedKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("private key is invalid")
+	}
+	return parsed, nil
+}
+
+func ParseINI(ini io.Reader) (map[string]map[string]string, error) {
+	result := map[string]map[string]string{
+		"": map[string]string{}, // root section
+	}
+	scanner := bufio.NewScanner(ini)
+	currentSection := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, ";") {
+			// comment.
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			currentSection = strings.TrimSpace(line[1 : len(line)-1])
+			result[currentSection] = map[string]string{}
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 && parts[0] != "" {
+			result[currentSection][strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning ini: %v", err)
+	}
+	return result, nil
+}
+
+func CondVal(v string) []string {
+	if v == "" {
+		return nil
+	}
+	return []string{v}
+}

--- a/vendor/golang.org/x/oauth2/internal/token.go
+++ b/vendor/golang.org/x/oauth2/internal/token.go
@@ -1,0 +1,225 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Token represents the crendentials used to authorize
+// the requests to access protected resources on the OAuth 2.0
+// provider's backend.
+//
+// This type is a mirror of oauth2.Token and exists to break
+// an otherwise-circular dependency. Other internal packages
+// should convert this Token into an oauth2.Token before use.
+type Token struct {
+	// AccessToken is the token that authorizes and authenticates
+	// the requests.
+	AccessToken string
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string
+
+	// Expiry is the optional expiration time of the access token.
+	//
+	// If zero, TokenSource implementations will reuse the same
+	// token forever and RefreshToken or equivalent
+	// mechanisms for that TokenSource will not be used.
+	Expiry time.Time
+
+	// Raw optionally contains extra metadata from the server
+	// when updating a token.
+	Raw interface{}
+}
+
+// tokenJSON is the struct representing the HTTP response from OAuth2
+// providers returning a token in JSON form.
+type tokenJSON struct {
+	AccessToken  string         `json:"access_token"`
+	TokenType    string         `json:"token_type"`
+	RefreshToken string         `json:"refresh_token"`
+	ExpiresIn    expirationTime `json:"expires_in"` // at least PayPal returns string, while most return number
+	Expires      expirationTime `json:"expires"`    // broken Facebook spelling of expires_in
+}
+
+func (e *tokenJSON) expiry() (t time.Time) {
+	if v := e.ExpiresIn; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	if v := e.Expires; v != 0 {
+		return time.Now().Add(time.Duration(v) * time.Second)
+	}
+	return
+}
+
+type expirationTime int32
+
+func (e *expirationTime) UnmarshalJSON(b []byte) error {
+	var n json.Number
+	err := json.Unmarshal(b, &n)
+	if err != nil {
+		return err
+	}
+	i, err := n.Int64()
+	if err != nil {
+		return err
+	}
+	*e = expirationTime(i)
+	return nil
+}
+
+var brokenAuthHeaderProviders = []string{
+	"https://accounts.google.com/",
+	"https://api.dropbox.com/",
+	"https://api.dropboxapi.com/",
+	"https://api.instagram.com/",
+	"https://api.netatmo.net/",
+	"https://api.odnoklassniki.ru/",
+	"https://api.pushbullet.com/",
+	"https://api.soundcloud.com/",
+	"https://api.twitch.tv/",
+	"https://app.box.com/",
+	"https://connect.stripe.com/",
+	"https://login.microsoftonline.com/",
+	"https://login.salesforce.com/",
+	"https://oauth.sandbox.trainingpeaks.com/",
+	"https://oauth.trainingpeaks.com/",
+	"https://oauth.vk.com/",
+	"https://openapi.baidu.com/",
+	"https://slack.com/",
+	"https://test-sandbox.auth.corp.google.com",
+	"https://test.salesforce.com/",
+	"https://user.gini.net/",
+	"https://www.douban.com/",
+	"https://www.googleapis.com/",
+	"https://www.linkedin.com/",
+	"https://www.strava.com/oauth/",
+	"https://www.wunderlist.com/oauth/",
+	"https://api.patreon.com/",
+}
+
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {
+	brokenAuthHeaderProviders = append(brokenAuthHeaderProviders, tokenURL)
+}
+
+// providerAuthHeaderWorks reports whether the OAuth2 server identified by the tokenURL
+// implements the OAuth2 spec correctly
+// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+// In summary:
+// - Reddit only accepts client secret in the Authorization header
+// - Dropbox accepts either it in URL param or Auth header, but not both.
+// - Google only accepts URL param (not spec compliant?), not Auth header
+// - Stripe only accepts client secret in Auth header with Bearer method, not Basic
+func providerAuthHeaderWorks(tokenURL string) bool {
+	for _, s := range brokenAuthHeaderProviders {
+		if strings.HasPrefix(tokenURL, s) {
+			// Some sites fail to implement the OAuth2 spec fully.
+			return false
+		}
+	}
+
+	// Assume the provider implements the spec properly
+	// otherwise. We can add more exceptions as they're
+	// discovered. We will _not_ be adding configurable hooks
+	// to this package to let users select server bugs.
+	return true
+}
+
+func RetrieveToken(ctx context.Context, ClientID, ClientSecret, TokenURL string, v url.Values) (*Token, error) {
+	hc, err := ContextClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	v.Set("client_id", ClientID)
+	bustedAuth := !providerAuthHeaderWorks(TokenURL)
+	if bustedAuth && ClientSecret != "" {
+		v.Set("client_secret", ClientSecret)
+	}
+	req, err := http.NewRequest("POST", TokenURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if !bustedAuth {
+		req.SetBasicAuth(ClientID, ClientSecret)
+	}
+	r, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+	}
+	if code := r.StatusCode; code < 200 || code > 299 {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v\nResponse: %s", r.Status, body)
+	}
+
+	var token *Token
+	content, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	switch content {
+	case "application/x-www-form-urlencoded", "text/plain":
+		vals, err := url.ParseQuery(string(body))
+		if err != nil {
+			return nil, err
+		}
+		token = &Token{
+			AccessToken:  vals.Get("access_token"),
+			TokenType:    vals.Get("token_type"),
+			RefreshToken: vals.Get("refresh_token"),
+			Raw:          vals,
+		}
+		e := vals.Get("expires_in")
+		if e == "" {
+			// TODO(jbd): Facebook's OAuth2 implementation is broken and
+			// returns expires_in field in expires. Remove the fallback to expires,
+			// when Facebook fixes their implementation.
+			e = vals.Get("expires")
+		}
+		expires, _ := strconv.Atoi(e)
+		if expires != 0 {
+			token.Expiry = time.Now().Add(time.Duration(expires) * time.Second)
+		}
+	default:
+		var tj tokenJSON
+		if err = json.Unmarshal(body, &tj); err != nil {
+			return nil, err
+		}
+		token = &Token{
+			AccessToken:  tj.AccessToken,
+			TokenType:    tj.TokenType,
+			RefreshToken: tj.RefreshToken,
+			Expiry:       tj.expiry(),
+			Raw:          make(map[string]interface{}),
+		}
+		json.Unmarshal(body, &token.Raw) // no error checks for optional fields
+	}
+	// Don't overwrite `RefreshToken` with an empty value
+	// if this was a token refreshing request.
+	if token.RefreshToken == "" {
+		token.RefreshToken = v.Get("refresh_token")
+	}
+	return token, nil
+}

--- a/vendor/golang.org/x/oauth2/internal/transport.go
+++ b/vendor/golang.org/x/oauth2/internal/transport.go
@@ -1,0 +1,69 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package internal contains support packages for oauth2 package.
+package internal
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+// HTTPClient is the context key to use with golang.org/x/net/context's
+// WithValue function to associate an *http.Client value with a context.
+var HTTPClient ContextKey
+
+// ContextKey is just an empty struct. It exists so HTTPClient can be
+// an immutable public variable with a unique type. It's immutable
+// because nobody else can create a ContextKey, being unexported.
+type ContextKey struct{}
+
+// ContextClientFunc is a func which tries to return an *http.Client
+// given a Context value. If it returns an error, the search stops
+// with that error.  If it returns (nil, nil), the search continues
+// down the list of registered funcs.
+type ContextClientFunc func(context.Context) (*http.Client, error)
+
+var contextClientFuncs []ContextClientFunc
+
+func RegisterContextClientFunc(fn ContextClientFunc) {
+	contextClientFuncs = append(contextClientFuncs, fn)
+}
+
+func ContextClient(ctx context.Context) (*http.Client, error) {
+	if ctx != nil {
+		if hc, ok := ctx.Value(HTTPClient).(*http.Client); ok {
+			return hc, nil
+		}
+	}
+	for _, fn := range contextClientFuncs {
+		c, err := fn(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if c != nil {
+			return c, nil
+		}
+	}
+	return http.DefaultClient, nil
+}
+
+func ContextTransport(ctx context.Context) http.RoundTripper {
+	hc, err := ContextClient(ctx)
+	// This is a rare error case (somebody using nil on App Engine).
+	if err != nil {
+		return ErrorTransport{err}
+	}
+	return hc.Transport
+}
+
+// ErrorTransport returns the specified error on RoundTrip.
+// This RoundTripper should be used in rare error cases where
+// error handling can be postponed to response handling time.
+type ErrorTransport struct{ Err error }
+
+func (t ErrorTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.Err
+}

--- a/vendor/golang.org/x/oauth2/oauth2.go
+++ b/vendor/golang.org/x/oauth2/oauth2.go
@@ -1,0 +1,337 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package oauth2 provides support for making
+// OAuth2 authorized and authenticated HTTP requests.
+// It can additionally grant authorization with Bearer JWT.
+package oauth2
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+)
+
+// NoContext is the default context you should supply if not using
+// your own context.Context (see https://golang.org/x/net/context).
+var NoContext = context.TODO()
+
+// RegisterBrokenAuthHeaderProvider registers an OAuth2 server
+// identified by the tokenURL prefix as an OAuth2 implementation
+// which doesn't support the HTTP Basic authentication
+// scheme to authenticate with the authorization server.
+// Once a server is registered, credentials (client_id and client_secret)
+// will be passed as query parameters rather than being present
+// in the Authorization header.
+// See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
+func RegisterBrokenAuthHeaderProvider(tokenURL string) {
+	internal.RegisterBrokenAuthHeaderProvider(tokenURL)
+}
+
+// Config describes a typical 3-legged OAuth2 flow, with both the
+// client application information and the server's endpoint URLs.
+type Config struct {
+	// ClientID is the application's ID.
+	ClientID string
+
+	// ClientSecret is the application's secret.
+	ClientSecret string
+
+	// Endpoint contains the resource server's token endpoint
+	// URLs. These are constants specific to each server and are
+	// often available via site-specific packages, such as
+	// google.Endpoint or github.Endpoint.
+	Endpoint Endpoint
+
+	// RedirectURL is the URL to redirect users going through
+	// the OAuth flow, after the resource owner's URLs.
+	RedirectURL string
+
+	// Scope specifies optional requested permissions.
+	Scopes []string
+}
+
+// A TokenSource is anything that can return a token.
+type TokenSource interface {
+	// Token returns a token or an error.
+	// Token must be safe for concurrent use by multiple goroutines.
+	// The returned Token must not be modified.
+	Token() (*Token, error)
+}
+
+// Endpoint contains the OAuth 2.0 provider's authorization and token
+// endpoint URLs.
+type Endpoint struct {
+	AuthURL  string
+	TokenURL string
+}
+
+var (
+	// AccessTypeOnline and AccessTypeOffline are options passed
+	// to the Options.AuthCodeURL method. They modify the
+	// "access_type" field that gets sent in the URL returned by
+	// AuthCodeURL.
+	//
+	// Online is the default if neither is specified. If your
+	// application needs to refresh access tokens when the user
+	// is not present at the browser, then use offline. This will
+	// result in your application obtaining a refresh token the
+	// first time your application exchanges an authorization
+	// code for a user.
+	AccessTypeOnline  AuthCodeOption = SetAuthURLParam("access_type", "online")
+	AccessTypeOffline AuthCodeOption = SetAuthURLParam("access_type", "offline")
+
+	// ApprovalForce forces the users to view the consent dialog
+	// and confirm the permissions request at the URL returned
+	// from AuthCodeURL, even if they've already done so.
+	ApprovalForce AuthCodeOption = SetAuthURLParam("approval_prompt", "force")
+)
+
+// An AuthCodeOption is passed to Config.AuthCodeURL.
+type AuthCodeOption interface {
+	setValue(url.Values)
+}
+
+type setParam struct{ k, v string }
+
+func (p setParam) setValue(m url.Values) { m.Set(p.k, p.v) }
+
+// SetAuthURLParam builds an AuthCodeOption which passes key/value parameters
+// to a provider's authorization endpoint.
+func SetAuthURLParam(key, value string) AuthCodeOption {
+	return setParam{key, value}
+}
+
+// AuthCodeURL returns a URL to OAuth 2.0 provider's consent page
+// that asks for permissions for the required scopes explicitly.
+//
+// State is a token to protect the user from CSRF attacks. You must
+// always provide a non-zero string and validate that it matches the
+// the state query parameter on your redirect callback.
+// See http://tools.ietf.org/html/rfc6749#section-10.12 for more info.
+//
+// Opts may include AccessTypeOnline or AccessTypeOffline, as well
+// as ApprovalForce.
+func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
+	var buf bytes.Buffer
+	buf.WriteString(c.Endpoint.AuthURL)
+	v := url.Values{
+		"response_type": {"code"},
+		"client_id":     {c.ClientID},
+		"redirect_uri":  internal.CondVal(c.RedirectURL),
+		"scope":         internal.CondVal(strings.Join(c.Scopes, " ")),
+		"state":         internal.CondVal(state),
+	}
+	for _, opt := range opts {
+		opt.setValue(v)
+	}
+	if strings.Contains(c.Endpoint.AuthURL, "?") {
+		buf.WriteByte('&')
+	} else {
+		buf.WriteByte('?')
+	}
+	buf.WriteString(v.Encode())
+	return buf.String()
+}
+
+// PasswordCredentialsToken converts a resource owner username and password
+// pair into a token.
+//
+// Per the RFC, this grant type should only be used "when there is a high
+// degree of trust between the resource owner and the client (e.g., the client
+// is part of the device operating system or a highly privileged application),
+// and when other authorization grant types are not available."
+// See https://tools.ietf.org/html/rfc6749#section-4.3 for more info.
+//
+// The HTTP client to use is derived from the context.
+// If nil, http.DefaultClient is used.
+func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string) (*Token, error) {
+	return retrieveToken(ctx, c, url.Values{
+		"grant_type": {"password"},
+		"username":   {username},
+		"password":   {password},
+		"scope":      internal.CondVal(strings.Join(c.Scopes, " ")),
+	})
+}
+
+// Exchange converts an authorization code into a token.
+//
+// It is used after a resource provider redirects the user back
+// to the Redirect URI (the URL obtained from AuthCodeURL).
+//
+// The HTTP client to use is derived from the context.
+// If a client is not provided via the context, http.DefaultClient is used.
+//
+// The code will be in the *http.Request.FormValue("code"). Before
+// calling Exchange, be sure to validate FormValue("state").
+func (c *Config) Exchange(ctx context.Context, code string) (*Token, error) {
+	return retrieveToken(ctx, c, url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"redirect_uri": internal.CondVal(c.RedirectURL),
+		"scope":        internal.CondVal(strings.Join(c.Scopes, " ")),
+	})
+}
+
+// Client returns an HTTP client using the provided token.
+// The token will auto-refresh as necessary. The underlying
+// HTTP transport will be obtained using the provided context.
+// The returned client and its Transport should not be modified.
+func (c *Config) Client(ctx context.Context, t *Token) *http.Client {
+	return NewClient(ctx, c.TokenSource(ctx, t))
+}
+
+// TokenSource returns a TokenSource that returns t until t expires,
+// automatically refreshing it as necessary using the provided context.
+//
+// Most users will use Config.Client instead.
+func (c *Config) TokenSource(ctx context.Context, t *Token) TokenSource {
+	tkr := &tokenRefresher{
+		ctx:  ctx,
+		conf: c,
+	}
+	if t != nil {
+		tkr.refreshToken = t.RefreshToken
+	}
+	return &reuseTokenSource{
+		t:   t,
+		new: tkr,
+	}
+}
+
+// tokenRefresher is a TokenSource that makes "grant_type"=="refresh_token"
+// HTTP requests to renew a token using a RefreshToken.
+type tokenRefresher struct {
+	ctx          context.Context // used to get HTTP requests
+	conf         *Config
+	refreshToken string
+}
+
+// WARNING: Token is not safe for concurrent access, as it
+// updates the tokenRefresher's refreshToken field.
+// Within this package, it is used by reuseTokenSource which
+// synchronizes calls to this method with its own mutex.
+func (tf *tokenRefresher) Token() (*Token, error) {
+	if tf.refreshToken == "" {
+		return nil, errors.New("oauth2: token expired and refresh token is not set")
+	}
+
+	tk, err := retrieveToken(tf.ctx, tf.conf, url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {tf.refreshToken},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	if tf.refreshToken != tk.RefreshToken {
+		tf.refreshToken = tk.RefreshToken
+	}
+	return tk, err
+}
+
+// reuseTokenSource is a TokenSource that holds a single token in memory
+// and validates its expiry before each call to retrieve it with
+// Token. If it's expired, it will be auto-refreshed using the
+// new TokenSource.
+type reuseTokenSource struct {
+	new TokenSource // called when t is expired.
+
+	mu sync.Mutex // guards t
+	t  *Token
+}
+
+// Token returns the current token if it's still valid, else will
+// refresh the current token (using r.Context for HTTP client
+// information) and return the new one.
+func (s *reuseTokenSource) Token() (*Token, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.t.Valid() {
+		return s.t, nil
+	}
+	t, err := s.new.Token()
+	if err != nil {
+		return nil, err
+	}
+	s.t = t
+	return t, nil
+}
+
+// StaticTokenSource returns a TokenSource that always returns the same token.
+// Because the provided token t is never refreshed, StaticTokenSource is only
+// useful for tokens that never expire.
+func StaticTokenSource(t *Token) TokenSource {
+	return staticTokenSource{t}
+}
+
+// staticTokenSource is a TokenSource that always returns the same Token.
+type staticTokenSource struct {
+	t *Token
+}
+
+func (s staticTokenSource) Token() (*Token, error) {
+	return s.t, nil
+}
+
+// HTTPClient is the context key to use with golang.org/x/net/context's
+// WithValue function to associate an *http.Client value with a context.
+var HTTPClient internal.ContextKey
+
+// NewClient creates an *http.Client from a Context and TokenSource.
+// The returned client is not valid beyond the lifetime of the context.
+//
+// As a special case, if src is nil, a non-OAuth2 client is returned
+// using the provided context. This exists to support related OAuth2
+// packages.
+func NewClient(ctx context.Context, src TokenSource) *http.Client {
+	if src == nil {
+		c, err := internal.ContextClient(ctx)
+		if err != nil {
+			return &http.Client{Transport: internal.ErrorTransport{err}}
+		}
+		return c
+	}
+	return &http.Client{
+		Transport: &Transport{
+			Base:   internal.ContextTransport(ctx),
+			Source: ReuseTokenSource(nil, src),
+		},
+	}
+}
+
+// ReuseTokenSource returns a TokenSource which repeatedly returns the
+// same token as long as it's valid, starting with t.
+// When its cached token is invalid, a new token is obtained from src.
+//
+// ReuseTokenSource is typically used to reuse tokens from a cache
+// (such as a file on disk) between runs of a program, rather than
+// obtaining new tokens unnecessarily.
+//
+// The initial token t may be nil, in which case the TokenSource is
+// wrapped in a caching version if it isn't one already. This also
+// means it's always safe to wrap ReuseTokenSource around any other
+// TokenSource without adverse effects.
+func ReuseTokenSource(t *Token, src TokenSource) TokenSource {
+	// Don't wrap a reuseTokenSource in itself. That would work,
+	// but cause an unnecessary number of mutex operations.
+	// Just build the equivalent one.
+	if rt, ok := src.(*reuseTokenSource); ok {
+		if t == nil {
+			// Just use it directly.
+			return rt
+		}
+		src = rt.new
+	}
+	return &reuseTokenSource{
+		t:   t,
+		new: src,
+	}
+}

--- a/vendor/golang.org/x/oauth2/token.go
+++ b/vendor/golang.org/x/oauth2/token.go
@@ -1,0 +1,158 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/internal"
+)
+
+// expiryDelta determines how earlier a token should be considered
+// expired than its actual expiration time. It is used to avoid late
+// expirations due to client-server time mismatches.
+const expiryDelta = 10 * time.Second
+
+// Token represents the crendentials used to authorize
+// the requests to access protected resources on the OAuth 2.0
+// provider's backend.
+//
+// Most users of this package should not access fields of Token
+// directly. They're exported mostly for use by related packages
+// implementing derivative OAuth2 flows.
+type Token struct {
+	// AccessToken is the token that authorizes and authenticates
+	// the requests.
+	AccessToken string `json:"access_token"`
+
+	// TokenType is the type of token.
+	// The Type method returns either this or "Bearer", the default.
+	TokenType string `json:"token_type,omitempty"`
+
+	// RefreshToken is a token that's used by the application
+	// (as opposed to the user) to refresh the access token
+	// if it expires.
+	RefreshToken string `json:"refresh_token,omitempty"`
+
+	// Expiry is the optional expiration time of the access token.
+	//
+	// If zero, TokenSource implementations will reuse the same
+	// token forever and RefreshToken or equivalent
+	// mechanisms for that TokenSource will not be used.
+	Expiry time.Time `json:"expiry,omitempty"`
+
+	// raw optionally contains extra metadata from the server
+	// when updating a token.
+	raw interface{}
+}
+
+// Type returns t.TokenType if non-empty, else "Bearer".
+func (t *Token) Type() string {
+	if strings.EqualFold(t.TokenType, "bearer") {
+		return "Bearer"
+	}
+	if strings.EqualFold(t.TokenType, "mac") {
+		return "MAC"
+	}
+	if strings.EqualFold(t.TokenType, "basic") {
+		return "Basic"
+	}
+	if t.TokenType != "" {
+		return t.TokenType
+	}
+	return "Bearer"
+}
+
+// SetAuthHeader sets the Authorization header to r using the access
+// token in t.
+//
+// This method is unnecessary when using Transport or an HTTP Client
+// returned by this package.
+func (t *Token) SetAuthHeader(r *http.Request) {
+	r.Header.Set("Authorization", t.Type()+" "+t.AccessToken)
+}
+
+// WithExtra returns a new Token that's a clone of t, but using the
+// provided raw extra map. This is only intended for use by packages
+// implementing derivative OAuth2 flows.
+func (t *Token) WithExtra(extra interface{}) *Token {
+	t2 := new(Token)
+	*t2 = *t
+	t2.raw = extra
+	return t2
+}
+
+// Extra returns an extra field.
+// Extra fields are key-value pairs returned by the server as a
+// part of the token retrieval response.
+func (t *Token) Extra(key string) interface{} {
+	if raw, ok := t.raw.(map[string]interface{}); ok {
+		return raw[key]
+	}
+
+	vals, ok := t.raw.(url.Values)
+	if !ok {
+		return nil
+	}
+
+	v := vals.Get(key)
+	switch s := strings.TrimSpace(v); strings.Count(s, ".") {
+	case 0: // Contains no "."; try to parse as int
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+	case 1: // Contains a single "."; try to parse as float
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			return f
+		}
+	}
+
+	return v
+}
+
+// expired reports whether the token is expired.
+// t must be non-nil.
+func (t *Token) expired() bool {
+	if t.Expiry.IsZero() {
+		return false
+	}
+	return t.Expiry.Add(-expiryDelta).Before(time.Now())
+}
+
+// Valid reports whether t is non-nil, has an AccessToken, and is not expired.
+func (t *Token) Valid() bool {
+	return t != nil && t.AccessToken != "" && !t.expired()
+}
+
+// tokenFromInternal maps an *internal.Token struct into
+// a *Token struct.
+func tokenFromInternal(t *internal.Token) *Token {
+	if t == nil {
+		return nil
+	}
+	return &Token{
+		AccessToken:  t.AccessToken,
+		TokenType:    t.TokenType,
+		RefreshToken: t.RefreshToken,
+		Expiry:       t.Expiry,
+		raw:          t.Raw,
+	}
+}
+
+// retrieveToken takes a *Config and uses that to retrieve an *internal.Token.
+// This token is then mapped from *internal.Token into an *oauth2.Token which is returned along
+// with an error..
+func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error) {
+	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v)
+	if err != nil {
+		return nil, err
+	}
+	return tokenFromInternal(tk), nil
+}

--- a/vendor/golang.org/x/oauth2/transport.go
+++ b/vendor/golang.org/x/oauth2/transport.go
@@ -1,0 +1,132 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"sync"
+)
+
+// Transport is an http.RoundTripper that makes OAuth 2.0 HTTP requests,
+// wrapping a base RoundTripper and adding an Authorization header
+// with a token from the supplied Sources.
+//
+// Transport is a low-level mechanism. Most code will use the
+// higher-level Config.Client method instead.
+type Transport struct {
+	// Source supplies the token to add to outgoing requests'
+	// Authorization headers.
+	Source TokenSource
+
+	// Base is the base RoundTripper used to make HTTP requests.
+	// If nil, http.DefaultTransport is used.
+	Base http.RoundTripper
+
+	mu     sync.Mutex                      // guards modReq
+	modReq map[*http.Request]*http.Request // original -> modified
+}
+
+// RoundTrip authorizes and authenticates the request with an
+// access token. If no token exists or token is expired,
+// tries to refresh/fetch a new token.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.Source == nil {
+		return nil, errors.New("oauth2: Transport's Source is nil")
+	}
+	token, err := t.Source.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	req2 := cloneRequest(req) // per RoundTripper contract
+	token.SetAuthHeader(req2)
+	t.setModReq(req, req2)
+	res, err := t.base().RoundTrip(req2)
+	if err != nil {
+		t.setModReq(req, nil)
+		return nil, err
+	}
+	res.Body = &onEOFReader{
+		rc: res.Body,
+		fn: func() { t.setModReq(req, nil) },
+	}
+	return res, nil
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		t.mu.Lock()
+		modReq := t.modReq[req]
+		delete(t.modReq, req)
+		t.mu.Unlock()
+		cr.CancelRequest(modReq)
+	}
+}
+
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+func (t *Transport) setModReq(orig, mod *http.Request) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.modReq == nil {
+		t.modReq = make(map[*http.Request]*http.Request)
+	}
+	if mod == nil {
+		delete(t.modReq, orig)
+	} else {
+		t.modReq[orig] = mod
+	}
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header, len(r.Header))
+	for k, s := range r.Header {
+		r2.Header[k] = append([]string(nil), s...)
+	}
+	return r2
+}
+
+type onEOFReader struct {
+	rc io.ReadCloser
+	fn func()
+}
+
+func (r *onEOFReader) Read(p []byte) (n int, err error) {
+	n, err = r.rc.Read(p)
+	if err == io.EOF {
+		r.runFunc()
+	}
+	return
+}
+
+func (r *onEOFReader) Close() error {
+	err := r.rc.Close()
+	r.runFunc()
+	return err
+}
+
+func (r *onEOFReader) runFunc() {
+	if fn := r.fn; fn != nil {
+		fn()
+		r.fn = nil
+	}
+}


### PR DESCRIPTION
```
$ cf cs dingo-postgresql cluster test3
Creating service instance test3 in org system / space dev as admin...
OK

Create in progress. Use 'cf services' or 'cf service test3' to check operation status.
```

At this point, CF now stores the `test3` name in its DB. This allows the broker to look it up, and then store it in the clusterdata backup S3 bucket, under the key `service_instance_name`:

```json
{"service_instance_name":"test3","instance_id":"2f096fb1-08fb-434d-ad04-2dc700b57785","service_id":"beb5973c-e1b2-11e5-a736-c7c0b526363d","plan_id":"1545e30e-6dc3-11e5-826a-6c4008a663f0","organization_guid":"fe50ba84-a587-4f2b-bc14-eb6fd9737fdc","space_guid":"2ae0cd76-bda3-47c4-9ba6-d060c67172eb","admin_credentials":{"username":"pgadmin","password":"oefuM4raCdr4QTB9"},"superuser_credentials":{"username":"postgres","password":"aWEoAX9Q1uT2j5li"},"app_credentials":{"username":"appuser","password":"yjQGJwoifMntPrjg"},"allocated_port":30011}
```